### PR TITLE
Revert to using keycloak image instead of phasetwo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ COPY --from=node /app/dist_keycloak/keycloak-theme-for-kc-25-and-above.jar /opt/
 RUN /opt/keycloak/bin/kc.sh build
 
 # Final image
-FROM quay.io/phasetwo/phasetwo-keycloak:25.0
+FROM quay.io/keycloak/keycloak:25.0
 COPY --from=keycloak_build /opt/keycloak/ /opt/keycloak/


### PR DESCRIPTION
Reverted to using keycloak docker image instead of `phasetwo/phasetwo-keycloak`. This is done in attempt to fix email sending from Keycloak.

phasetwo/phasetwo-keycloak was introduced to add hooks on user creation, but might be causing some issues with email sending