### PR TITLE
List all social providers on the login page

### DIFF
--- a/src/login/pages/Login.tsx
+++ b/src/login/pages/Login.tsx
@@ -125,11 +125,15 @@ export default function Login(props: PageProps<Extract<KcContext, { pageId: "log
                                         </a>
 
                                         <br />
-                                        {social?.providers &&
-                                            <a href={social.providers[1]?.loginUrl}>
-                                                Staff login
-                                            </a>
-                                        }
+                                        {social?.providers && social.providers.length && (
+                                            social.providers.map(provider => (
+                                                <div>
+                                                    <a key={provider.alias} href={provider.loginUrl}>
+                                                        {provider.displayName}
+                                                    </a>
+                                                </div>
+                                            ))
+                                        )}
                                     </p>
                                 </div>
                                 <input


### PR DESCRIPTION
In dev we have two staff login options: EY Login and "Staff Login" (which is the MVRB admin login), we need to show both so we can test it out