### PR TITLE
add workflow for pushing the custom keycloak image to prod

### DIFF
--- a/.github/workflows/promote-theme-to-prod.yaml
+++ b/.github/workflows/promote-theme-to-prod.yaml
@@ -1,0 +1,29 @@
+name: Build and Push Keycloak Image to Prod
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Login to Azure Container Registry
+        uses: azure/docker-login@v2
+        with:
+          login-server: mvrbprodregistry.azurecr.io
+          username: ${{ secrets.ACR_PROD_USERNAME }}
+          password: ${{ secrets.ACR_PROD_PASSWORD }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Keycloak Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          push: true
+          tags: mvrbprodregistry.azurecr.io/keycloak:latest,mvrbprodregistry.azurecr.io/keycloak:${{ github.sha }}


### PR DESCRIPTION
Added workflow to push custom keycloak image to the prod container registry
Reverted base keycloak image back to the official release since we aren't using the custom functionality of the image we were using.